### PR TITLE
Ergonomics improvements (keypad_new and RefCell in release are no more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For an example that runs on an actual microcontroller, see
 use core::convert::Infallible;
 use embedded_hal::digital::v2::InputPin;
 use keypad::mock_hal::{self, GpioExt, Input, OpenDrain, Output, PullUp, GPIOA};
-use keypad::{keypad_new, keypad_struct};
+use keypad::keypad_struct;
 
 // Define the struct that represents your keypad matrix circuit,
 // picking the row and column pin numbers.
@@ -88,21 +88,21 @@ fn main() {
     let pins = GPIOA::split();
 
     // Create an instance of the keypad struct you defined above.
-    let keypad = keypad_new!(ExampleKeypad {
-        rows: (
+    let keypad = ExampleKeypad::new(
+        (
             pins.pa0.into_pull_up_input(),
             pins.pa1.into_pull_up_input(),
             pins.pa2.into_pull_up_input(),
             pins.pa3.into_pull_up_input(),
-        ),
-        columns: (
+        ), // rows
+        (
             pins.pa4.into_open_drain_output(),
             pins.pa5.into_open_drain_output(),
             pins.pa6.into_open_drain_output(),
             pins.pa7.into_open_drain_output(),
             pins.pa8.into_open_drain_output(),
-        ),
-    });
+        ), // columns
+    );
 
     // Create a 2d array of virtual `KeypadInput` pins, each representing 1 key
     // in the matrix. They implement the `InputPin` trait and can (mostly) be

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,8 +6,8 @@
 
 use core::convert::Infallible;
 use embedded_hal::digital::v2::InputPin;
+use keypad::keypad_struct;
 use keypad::mock_hal::{self, GpioExt, Input, OpenDrain, Output, PullUp, GPIOA};
-use keypad::{keypad_new, keypad_struct};
 
 // Define the struct that represents your keypad matrix. Give the specific pins
 // that will be used for the rows and columns of your matrix - each pin number
@@ -37,21 +37,21 @@ fn main() {
     let pins = GPIOA::split();
 
     // Create an instance of the keypad struct you defined above.
-    let keypad = keypad_new!(ExampleKeypad {
-        rows: (
+    let keypad = ExampleKeypad::new(
+        (
             pins.pa0.into_pull_up_input(),
             pins.pa1.into_pull_up_input(),
             pins.pa2.into_pull_up_input(),
             pins.pa3.into_pull_up_input(),
         ),
-        columns: (
+        (
             pins.pa4.into_open_drain_output(),
             pins.pa5.into_open_drain_output(),
             pins.pa6.into_open_drain_output(),
             pins.pa7.into_open_drain_output(),
             pins.pa8.into_open_drain_output(),
         ),
-    });
+    );
 
     // Create a 2d array of virtual `KeypadInput` pins, each representing 1 key in the
     // matrix. They implement the `InputPin` trait and can (mostly) be used

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,14 +367,14 @@ macro_rules! keypad_struct {
             ///         pins.pa1.into_pull_up_input(),
             ///         pins.pa2.into_pull_up_input(),
             ///         pins.pa3.into_pull_up_input(),
-            ///     ), //rows
+            ///     ), // rows
             ///     (
             ///         pins.pa4.into_open_drain_output(),
             ///         pins.pa5.into_open_drain_output(),
             ///         pins.pa6.into_open_drain_output(),
             ///         pins.pa7.into_open_drain_output(),
             ///         pins.pa8.into_open_drain_output(),
-            ///     ), //columns
+            ///     ), // columns
             /// );
             /// # }
             /// ```


### PR DESCRIPTION
Hello, and thank you for the library.

I hope this PR will be useful.

Motivation:
- I am testing my hardware setup, and I would like to reuse my keypad code in several applications;
- the struct fields are always private (as should be, I think), thus it is not possible to instantiate the struct with `keypad_new` anywhere else other than the origin module;
- to circumvent that, I would need to write a "new" function, i.e I have to repeat all the types in the signature and write `RefCell` wrapping;
- if I change the wiring and so the struct signature, I have to rewrite that function and I would like to avoid it.

Thus, in this PR I removed `keypad_new` macro and implemented `new` function in the main macro (RefCell wrapping included).
As an additional improvement, `release` method now returns pins without `RefCell`.

(I don't really like the macro rule duplication, but it works.)